### PR TITLE
fix ralm running code

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,13 @@ make train-query MODEL_NAME=NEW_MODEL_SAVE_DIR DUMP_DIR=$SAVE_DIR/densephrases-m
 * After optimize your retriever, you can feed retrieved collection into generative language model (GLM).
 * Below command will launch `gradio` based web demo for GLM chatbot augmented with densephrase retriever.
 ```bash
-export OPENAI_API_KEY=YOUR_API_KEY; python run_ralm.py --index_name INDEX_NAME --question QUESTION
+export OPENAI_API_KEY=YOUR_API_KEY; python run_ralm.py --index_name INDEX_NAME
 ```
+* index_path: $SAVE_DIR/densephrases-multi_wiki-20181220/dump/$INDEX_NAME
+  * INDEX_NAME default: start/1048576_flat_OPQ96_small
 * GLM API
   * default: `gpt-3.5-turbo-16k-0613` of OpenAI
-  * HyperClova
+  * HyperClova studio
 <details>
   <summary> generated answer example</summary>
 Query: Where are mucosal associated lymphoid tissues present in the human body and why?

--- a/run_ralm.py
+++ b/run_ralm.py
@@ -4,7 +4,7 @@ import sys
 import argparse
 from typing import List
 
-from langchain.chat_models import ChatOpenAI # for `gpt-3.5-turbo` & `gpt-4` 
+from langchain.chat_models import ChatOpenAI  # for `gpt-3.5-turbo` & `gpt-4`
 from langchain.chains import RetrievalQAWithSourcesChain
 from langchain.prompts import (
     ChatPromptTemplate,
@@ -16,14 +16,15 @@ import gradio as gr
 
 from retrieve import Retriever
 
-DEFAULT_QUESTION="Wikipedia 2018 english dump에서 궁금한 점을 질문해주세요.\n예를들어 \n\n- Where are mucosal associated lymphoid tissues present in the human body and why?\n- When did korean drama started in the philippines?\n- When did the financial crisis in greece start?"
-TEMPERATURE=0
+DEFAULT_QUESTION = "Wikipedia 2018 english dump에서 궁금한 점을 질문해주세요.\n예를들어 \n\n- Where are mucosal associated lymphoid tissues present in the human body and why?\n- When did korean drama started in the philippines?\n- When did the financial crisis in greece start?"
+TEMPERATURE = 0
+
 
 class LangChainCustomRetrieverWrapper(BaseRetriever):
     def __init__(self, args):
         self.args = args
 
-        self.retriever = Retriever(args) # DensePhrase
+        self.retriever = Retriever(args)  # DensePhrase
 
     def get_relevant_documents(self, query: str) -> List[Document]:
         """Get texts relevant for a query.
@@ -41,20 +42,25 @@ class LangChainCustomRetrieverWrapper(BaseRetriever):
         results = self.retriever.retrieve(single_query_or_queries_dict=query)
 
         # make result list of Document object
-        return [Document(page_content=result, metadata={'source': f'source_{idx}'}) for idx, result in enumerate(results)]
-        
-    async def aget_relevant_documents(self, query: str) -> List[Document]: # abstractmethod
+        return [
+            Document(page_content=result, metadata={"source": f"source_{idx}"})
+            for idx, result in enumerate(results)
+        ]
+
+    async def aget_relevant_documents(
+        self, query: str
+    ) -> List[Document]:  # abstractmethod
         raise NotImplementedError
-    
+
+
 class RaLM:
     def __init__(self, args):
         self.args = args
-        self.initialize_ralm() 
-
+        self.initialize_ralm()
 
     def initialize_ralm(self):
         # initialize custom retriever
-        self.retriever = LangChainCustomRetrieverWrapper(args)
+        self.retriever = LangChainCustomRetrieverWrapper(self.args)
 
         # prompt for RaLM
         system_template = """Use the following pieces of context to answer the users question.
@@ -64,7 +70,7 @@ class RaLM:
         {summaries}"""
         messages = [
             SystemMessagePromptTemplate.from_template(system_template),
-            HumanMessagePromptTemplate.from_template("{question}")
+            HumanMessagePromptTemplate.from_template("{question}"),
         ]
         prompt = ChatPromptTemplate.from_messages(messages)
         chain_type_kwargs = {"prompt": prompt}
@@ -84,85 +90,103 @@ class RaLM:
         result = self.chain({"question": question})
 
         # postprocess
-        result['answer'] = self.postprocess(result['answer'])
-        if isinstance(result['sources'], str):
-            result['sources'] = self.postprocess(result['sources'])
-            result['sources'] = result['sources'].split(', ')
-            result['sources'] = [src.strip() for src in result['sources']]
+        result["answer"] = self.postprocess(result["answer"])
+        if isinstance(result["sources"], str):
+            result["sources"] = self.postprocess(result["sources"])
+            result["sources"] = result["sources"].split(", ")
+            result["sources"] = [src.strip() for src in result["sources"]]
 
         # print result
         self.print_result(result)
 
         return result
-    
+
     def print_result(self, result):
         print(f"Answer: {result['answer']}")
 
         print(f"Sources: ")
-        print(result['sources'])
-        assert(isinstance(result['sources'], list))
-        nSource = len(result['sources'])
+        print(result["sources"])
+        assert isinstance(result["sources"], list)
+        nSource = len(result["sources"])
 
         for i in range(nSource):
-            source_title = result['sources'][i]
+            source_title = result["sources"][i]
             print(f"{source_title}: ")
-            if 'source_documents' in result:
-                for j in range(len(result['source_documents'])):
-                    if result['source_documents'][j].metadata['source'] == source_title:
-                        print(result['source_documents'][j].page_content)
+            if "source_documents" in result:
+                for j in range(len(result["source_documents"])):
+                    if result["source_documents"][j].metadata["source"] == source_title:
+                        print(result["source_documents"][j].page_content)
                         break
 
     def postprocess(self, text):
         # remove final parenthesis (bug with unknown cause)
-        if text.endswith(')') or text.endswith('(') or text.endswith('[') or text.endswith(']'):
-            text = text[:-1]        
-        
-        return text.strip()
-    
+        if (
+            text.endswith(")")
+            or text.endswith("(")
+            or text.endswith("[")
+            or text.endswith("]")
+        ):
+            text = text[:-1]
 
-if __name__ == "__main__":   
-    parser = argparse.ArgumentParser(description='Ask a question to the notion DB.')
+        return text.strip()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Ask a question to the notion DB.")
 
     # General
-    parser.add_argument('--question', type=str, default=None, required=True, help='The question to ask for database')
-    parser.add_argument('--model_name', type=str, default='gpt-3.5-turbo-16k-0613', help='model name for openai api')
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="gpt-3.5-turbo-16k-0613",
+        help="model name for openai api",
+    )
 
     # Retriever: Densephrase
-    parser.add_argument('--query_encoder_name_or_dir', type=str, default="princeton-nlp/densephrases-multi-query-multi",
-                        help="query encoder name registered in huggingface model hub OR custom query encoder checkpoint directory")
-    parser.add_argument('--index_name', type=str, default="1048576_flat_OPQ96",
-                        help="index name appended to index directory prefix")
-    
+    parser.add_argument(
+        "--query_encoder_name_or_dir",
+        type=str,
+        default="princeton-nlp/densephrases-multi-query-multi",
+        help="query encoder name registered in huggingface model hub OR custom query encoder checkpoint directory",
+    )
+    parser.add_argument(
+        "--index_name",
+        type=str,
+        default="start/1048576_flat_OPQ96_small",
+        help="index name appended to index directory prefix",
+    )
+
     args = parser.parse_args()
 
     # to prevent collision with DensePhrase native argparser
     sys.argv = [sys.argv[0]]
 
     # initialize class
-    app = RaLM(args) 
-    
+    app = RaLM(args)
+
     def question_answer(question):
         result = app.run_chain(question=question, force_korean=False)
-        
-        return result['answer'],\
-                '\n######################################################\n\n'.join([f"Source {idx}\n{doc.page_content}" for idx, doc in enumerate(result['source_documents'])])
+
+        return result[
+            "answer"
+        ], "\n######################################################\n\n".join(
+            [
+                f"Source {idx}\n{doc.page_content}"
+                for idx, doc in enumerate(result["source_documents"])
+            ]
+        )
 
     # launch gradio
     gr.Interface(
-    fn=question_answer, 
-    inputs=gr.inputs.Textbox(
-        default=DEFAULT_QUESTION, 
-        label="질문"
-        ), 
-    outputs=[
-        gr.inputs.Textbox(
-        default="챗봇의 답변을 표시합니다.", 
-        label="생성된 답변"),
-        gr.inputs.Textbox(
-        default="prompt에 사용된 검색 결과들을 표시합니다.", 
-        label="prompt에 첨부된 검색 결과들"),
-        ], 
-    title="지식기반 챗봇",
-    theme='dark-grass',
-    description="사용자의 지식베이스에 기반해서 대화하는 챗봇입니다.\n본 예시에서는 wikipedia dump에서 검색한 후 이를 바탕으로 답변을 생성합니다.\n\n retriever: densePhrase, generator: gpt-3.5-turbo-16k-0613 (API)"
+        fn=question_answer,
+        inputs=gr.inputs.Textbox(default=DEFAULT_QUESTION, label="질문"),
+        outputs=[
+            gr.inputs.Textbox(default="챗봇의 답변을 표시합니다.", label="생성된 답변"),
+            gr.inputs.Textbox(
+                default="prompt에 사용된 검색 결과들을 표시합니다.", label="prompt에 첨부된 검색 결과들"
+            ),
+        ],
+        title="지식기반 챗봇",
+        theme="dark-grass",
+        description="사용자의 지식베이스에 기반해서 대화하는 챗봇입니다.\n본 예시에서는 wikipedia dump에서 검색한 후 이를 바탕으로 답변을 생성합니다.\n\n retriever: densePhrase, generator: gpt-3.5-turbo-16k-0613 (API)",
     ).launch(share=True)


### PR DESCRIPTION
* run_ralm.py 실행에 오류가 있어서 수정 후 README update

## test
* cmd
`export OPENAI_API_KEY=$OPENAI_API; python run_ralm.py --index_name start/1048576_flat_OPQ96_small`
</br>

* out
![image](https://github.com/nota-github/retrieved_collection_compression_BOOSTCAMP/assets/127937907/16490a97-0b5b-4b1d-88c7-db62c9a9d5ae)


* log
```
This could take up to 15 mins depending on the file reading speed of HDD/SSD
self.index:  <faiss.swigfaiss.IndexPreTransform; proxy of <Swig Object of type 'faiss::IndexPreTransform *' at 0x7f4ce94ddea0> >
Loading DensePhrases Completed!
/opt/conda/lib/python3.8/site-packages/gradio/inputs.py:27: UserWarning: Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your component from gradio.components
  warnings.warn(
/opt/conda/lib/python3.8/site-packages/gradio/inputs.py:30: UserWarning: `optional` parameter is deprecated, and it has no effect
  super().__init__(
/opt/conda/lib/python3.8/site-packages/gradio/inputs.py:30: UserWarning: `numeric` parameter is deprecated, and it has no effect
  super().__init__(
/opt/conda/lib/python3.8/site-packages/gradio/blocks.py:680: UserWarning: Cannot load dark-grass. Caught Exception: The space dark-grass does not exist
  warnings.warn(f"Cannot load {theme}. Caught Exception: {str(e)}")
Running on local URL:  http://127.0.0.1:7860/
Running on public URL: https://5a320734e466a1ebef.gradio.live/

This share link expires in 72 hours. For free permanent hosting and GPU upgrades, run `gradio deploy` from Terminal to deploy to Spaces (https://huggingface.co/spaces)
```

* 